### PR TITLE
Revise README to include team and project information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
-# teams
-Coordination repository of the `riscv-rust` organization
+# Rust on RISC-V
+
+> Coordination repository of the `riscv-rust` organization
+
+This repository [issue tracker] is used by the `riscv-rust` organization to coordinate efforts towards making Rust a great choice for embedded development on RISC-V chips.
+
+## Organization
+
+We are composed of several teams.
+This section lists all the teams and all the projects owned by `riscv-rust`.
+
+### The `rust-embedded` team
+
+This team administers the organization and has admin rights to all the repositories.
+
+#### Members
+
+- [@disasm]
+- [@romancardenas]
+
+### The `e310x` team
+
+Maintains all the crates related to E310x chips.
+
+#### Members
+
+- [@romancardenas]
+
+#### Projects
+
+Projects maintained by this team.
+
+- [`e310x`]
+
+### The `gd32vf103` team
+
+Maintains all the crates related to GD32VF103x chips.
+
+#### Members
+
+- [@disasm]
+
+#### Projects
+
+- [`gd32vf103-pac`]
+- [`gd32vf103xx-hal`]
+- [`logan-nano`]
+
+
+
+
+[issue tracker]: https://github.com/riscv-rust/teams/issues
+
+[`e310x`]: https://github.com/riscv-rust/e310x
+[`gd32vf103-pac`]: https://github.com/riscv-rust/gd32vf103-pac
+[`gd32vf103xx-hal`]: https://github.com/riscv-rust/gd32vf103xx-hal
+[`logan-nano`]: https://github.com/riscv-rust/logan-nano
+
+[@disasm]: https://github.com/disasm
+[@romancardenas]: https://github.com/romancardenas

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Maintains all the crates related to E310x chips.
 Projects maintained by this team.
 
 - [`e310x`]
+- [`riscv-rust-quickstart`]
 
 ### The `gd32vf103` team
 
@@ -45,6 +46,7 @@ Maintains all the crates related to GD32VF103x chips.
 - [`gd32vf103-pac`]
 - [`gd32vf103xx-hal`]
 - [`logan-nano`]
+- [`seedstudio-gd32v`]
 
 
 
@@ -52,9 +54,11 @@ Maintains all the crates related to GD32VF103x chips.
 [issue tracker]: https://github.com/riscv-rust/teams/issues
 
 [`e310x`]: https://github.com/riscv-rust/e310x
+[`riscv-rust-quickstart`]: https://github.com/riscv-rust/riscv-rust-quickstart
 [`gd32vf103-pac`]: https://github.com/riscv-rust/gd32vf103-pac
 [`gd32vf103xx-hal`]: https://github.com/riscv-rust/gd32vf103xx-hal
 [`logan-nano`]: https://github.com/riscv-rust/logan-nano
+[`seedstudio-gd32v`]: https://github.com/riscv-rust/seedstudio-gd32v
 
 [@disasm]: https://github.com/disasm
 [@romancardenas]: https://github.com/romancardenas


### PR DESCRIPTION
The idea is to clarify how the crates of this organization are managed. Following the scheme of the Rust Embedded WG, this repo will contain all the people contributing to the organization and which repos are maintained by whom.

@riscv-rust/rust-embedded currently, I only added @Disasm and me to the list of "core" maintainers. Please, use this PR to assert that you are OK with this idea and, if so, confirm that you are willing to continue maintaining the organization.

Once we are happy with this repo, we can use the PR approach to let other users join the organization and contribute to specific chips (e.g., [gd32vf103](https://github.com/riscv-rust/gd32vf103xx-hal)).

@rmsyn , as you are also part of the Embedded Rust WG, feel free to join the core team if you are willing to help maintain any of our crates.