### PR TITLE
Nominate myself to gd32vf103 team

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Maintains all the crates related to GD32VF103x chips.
 #### Members
 
 - [@disasm]
+- [@dcz-self]
 
 #### Projects
 

--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ Maintains all the crates related to GD32VF103x chips.
 
 [@disasm]: https://github.com/disasm
 [@romancardenas]: https://github.com/romancardenas
+[@dcz-self]: https://dorotac.eu


### PR DESCRIPTION
This is a follow-up on https://github.com/riscv-rust/gd32vf103xx-hal/issues/62#issuecomment-3311853372

I'm working on a project using the GD32VF103 and I found/fixed some problems already. I'd like to make sure the upstream version is always useable.