### PR TITLE
Add contribution policy of gd32vf103 team

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ Maintains all the crates related to GD32VF103x chips.
 - [`longan-nano`]
 - [`seedstudio-gd32v`]
 
+#### Contribution policy
 
+Applies to all crates maintained by this team. The policy may change as needed.
+
+- Pushes to master are not allowed.
+- If a pull request stays open for a week without activity, any maintainer (including the author) is allowed to merge it immediately.
 
 
 [issue tracker]: https://github.com/riscv-rust/teams/issues


### PR DESCRIPTION
As discussed in https://github.com/riscv-rust/teams/issues/4 .

I made some implied things explicit:
- the policy is changeable, so we could stabilize if people start relying on the crates,
- pushing to master is too fast.

Rationale not included in the text to keep it short.